### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ kamene
 colorama
 requests
 flask_ngrok
+trio


### PR DESCRIPTION
IRIS wouldn't run because I didn't have `trio`, something that should be reflected in the `requirements.txt`